### PR TITLE
[fix] fix issues when no test or no assert names are provided

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+# Unreleased
+
+- fixes issue when no assert name is provided
+- fixes issue when no test name is provided with TAP comment
+
 # 1.0.1 (04/20/2019)
 
 - fixes backwards compatibility with node@8

--- a/index.js
+++ b/index.js
@@ -14,19 +14,23 @@ module.exports = function tapHTML (callback) {
 
   const startTime = Date.now();
 
+  function pushTest(name) {
+    data.push({
+      type: 'test',
+      name: name,
+      start: Date.now(),
+      assertions: []
+    });
+
+    // get the current index of the plan
+    // so that we can use this to push the current assertions to it
+    currentPlan += 1;
+    currentAssertion = -1;
+  }
+
   tap.on('comment', (res) => {
     if (!plan) {
-      data.push({
-        type: 'test',
-        name: res,
-        start: Date.now(),
-        assertions: []
-      });
-
-      // get the current index of the plan
-      // so that we can use this to push the current assertions to it
-      currentPlan += 1;
-      currentAssertion = -1;
+      pushTest(res);
     }
   });
 
@@ -43,6 +47,16 @@ module.exports = function tapHTML (callback) {
   });
 
   tap.on('assert', (res) => {
+    // If no plan is registered yet, create a default plan.
+    if(currentPlan == -1) {
+      pushTest('default');
+    }
+
+    // TAP does not require a name. If no name is registered, set a default name.
+    if (!res.name) {
+      res.name = 'test #' + res.id;
+    }
+
     data[currentPlan].assertions.push({
       type: 'assert',
       number: res.id,


### PR DESCRIPTION
The goal of this PR is to improve compatibility with possible output of tap-parser module.

Currently it seems that tap-html is expecting TAP comment to be used to group assertions in a 'test' named according to the comment. This does not seems to be specified in TAP13 nor in TAP14. This is not documented in the README either.

The solution (that might be discussed) is to create a default test if none exists when the first assertion is received.

Another fix is introduced if no assertion name exists, by creating one from the assertion ID.

This could be tested with the [simple.tap](https://github.com/tapjs/tap-parser/blob/main/test/fixtures/simple.tap) test file from tap-parser.