### PR TITLE
Restore behavior described in README.md when no output file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# Unreleased
+
+- Change behavior when no output file is given to tap-html to restore what is described in README.md
+
 # 1.0.1 (04/20/2019)
 
 - fixes backwards compatibility with node@8

--- a/bin/index.js
+++ b/bin/index.js
@@ -47,11 +47,15 @@ const { out } = program;
 
 process.stdin
   .pipe(parser((res) => {
-    const outputPath = out ? path.resolve(__dirname, out) : path.resolve(process.cwd(), 'tap.html');
-
     // generate the html report
     const output = generate(res);
 
-    fs.writeFileSync(outputPath, output);
+    // Produce output either in a file or on stdout.
+    if (out) {
+      const outputPath = path.resolve(__dirname, out);
+      fs.writeFileSync(outputPath, output);
+    } else {
+      process.stdout.write(output);
+    }
   }))
   .pipe(process.stdout);


### PR DESCRIPTION
The behavior described in the README.md is not the one implemented.
The goal of this PR is to restore this so that if no output file is provided on the command line, the output is written on stdout.